### PR TITLE
Allow razor templates with the same name in different folders with different namespaces

### DIFF
--- a/MiniRazor.CodeGen/TemplateClassGenerator.cs
+++ b/MiniRazor.CodeGen/TemplateClassGenerator.cs
@@ -24,6 +24,16 @@ namespace MiniRazor.CodeGen
                 .Value
                 .NullIfWhiteSpace();
 
+        private static string? TryGetNamespace(string code) =>
+            Regex.Match(
+                    code,
+                    @"namespace (\S+)",
+                    RegexOptions.Multiline, TimeSpan.FromSeconds(1)
+                )
+                .Groups[1]
+                .Value
+                .NullIfWhiteSpace();
+
         private static string RemoveNullableDirectives(string code) =>
             Regex.Replace(
                 code,
@@ -53,6 +63,8 @@ namespace MiniRazor.CodeGen
 
             // Get model type from the template's base class
             var modelTypeName = TryGetModelTypeName(code, className) ?? "dynamic";
+
+            var @namespace = TryGetNamespace(code);
 
             // Disable nullability checks on the entire file
             code = RemoveNullableDirectives(code)
@@ -90,7 +102,7 @@ public static async global::System.Threading.Tasks.Task<string> RenderAsync({mod
 }}
 ");
 
-            context.AddSource(className, code);
+            context.AddSource(@namespace is not null ? $"{@namespace}.{className}" : className, code);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
The current source generator only uses the generated class name as the hint name when adding the generated source.  As the generated class name is simply the filename of the template, if two templates are in different folders with the same name, the generator fails to generate the source code, as they would have the same hint name.  By using different namespaces for these templates, and including the namespace as part of the hint name, this gets around the issue by making the hint names unique.